### PR TITLE
All the sent JSON to be accessed after the fact

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/RoboticsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/RoboticsService.java
@@ -28,6 +28,8 @@ public class RoboticsService {
     private final RoboticsJsonValidator roboticsJsonValidator;
     private final RoboticsEmailTemplate roboticsEmailTemplate;
 
+    private JSONObject roboticsJson;
+
     @Autowired
     public RoboticsService(
             AirLookupService airLookupService,
@@ -50,7 +52,7 @@ public class RoboticsService {
     public void sendCaseToRobotics(SscsCaseData caseData, Long caseId, String postcode, byte[] pdf, Map<String, byte[]> additionalEvidence) {
         String venue = airLookupService.lookupAirVenueNameByPostCode(postcode);
 
-        JSONObject roboticsJson = createRobotics(RoboticsWrapper.builder().sscsCaseData(caseData)
+        roboticsJson = createRobotics(RoboticsWrapper.builder().sscsCaseData(caseData)
                 .ccdCaseId(caseId).venueName(venue).evidencePresent(caseData.getEvidencePresent()).build());
 
         sendJsonByEmail(caseData.getAppeal().getAppellant(), roboticsJson, pdf, additionalEvidence);
@@ -95,6 +97,10 @@ public class RoboticsService {
         }
 
         return emailAttachments;
+    }
+
+    public JSONObject getRoboticsJson() {
+        return roboticsJson;
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsServiceTest.java
@@ -161,4 +161,22 @@ public class RoboticsServiceTest {
         verify(roboticsJsonValidator).validate(mappedJson);
         verify(emailService).sendEmail(any());
     }
+
+    @Test
+    public void generatingRoboticsStoresTheJson() {
+
+        SscsCaseData appeal = buildCaseData();
+
+        JSONObject mappedJson = mock(JSONObject.class);
+
+        given(roboticsJsonMapper.map(any())).willReturn(mappedJson);
+
+        given(airlookupService.lookupAirVenueNameByPostCode("AB12 XYZ")).willReturn("Bristol");
+
+        given(emailService.generateUniqueEmailId(appeal.getAppeal().getAppellant())).willReturn("Bloggs_123");
+
+        service.sendCaseToRobotics(appeal, 123L, "AB12 XYZ", null);
+
+        assertThat(service.getRoboticsJson(), is(mappedJson));
+    }
 }


### PR DESCRIPTION
A new method getRoboticsJson() allows the caller to look at the JSON that was sent to Robotics. This was driven by a requirement in the following ticket:

https://tools.hmcts.net/jira/browse/SSCS-4595