### PR TITLE
Sscs 4595 store robotics json

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadService.java
@@ -120,7 +120,7 @@ public class RoboticsJsonUploadService {
 
     private DocumentLink getDocumentLink(UploadResponse uploadResponse) {
         if (null != uploadResponse) {
-            final String href = uploadResponse.getEmbedded().getDocuments().get(0).links.binary.href;
+            final String href = uploadResponse.getEmbedded().getDocuments().get(0).links.self.href;
             return DocumentLink.builder().documentUrl(href).build();
         } else {
             log.info("No document link available - document store may be down");

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadService.java
@@ -74,7 +74,7 @@ public class RoboticsJsonUploadService {
 
     }
 
-    public SscsCaseData attachRoboticsJsonToCaseData(SscsCaseData caseData, UploadResponse uploadResponse) {
+    private SscsCaseData attachRoboticsJsonToCaseData(SscsCaseData caseData, UploadResponse uploadResponse) {
         DocumentLink documentLink = getDocumentLink(uploadResponse);
 
         if (null != documentLink) {
@@ -92,6 +92,20 @@ public class RoboticsJsonUploadService {
 
         return null;
 
+    }
+
+    private UploadResponse uploadRoboticsJson(List<MultipartFile> files) {
+
+        String serviceAuthorization = authTokenGenerator.generate();
+
+        try {
+            return documentUploadClientApi
+                    .upload(S2S_TOKEN, serviceAuthorization, DM_STORE_USER_ID, files);
+        } catch (Exception e) {
+            log.info("Doc Store service failed to upload Robotics JSON, but carrying on", e);
+        }
+
+        return null;
     }
 
     private SscsDocument getRoboticsJsonDocument(DocumentLink documentLink) {
@@ -125,19 +139,4 @@ public class RoboticsJsonUploadService {
         }
         return sscsDocumentList;
     }
-
-    public UploadResponse uploadRoboticsJson(List<MultipartFile> files) {
-
-        String serviceAuthorization = authTokenGenerator.generate();
-
-        try {
-            return documentUploadClientApi
-                    .upload(S2S_TOKEN, serviceAuthorization, DM_STORE_USER_ID, files);
-        } catch (Exception e) {
-            log.info("Doc Store service failed to upload Robotics JSON, but carrying on", e);
-        }
-
-        return null;
-    }
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadService.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.sscs.service;
 
 import static java.util.Collections.singletonList;
-import static org.springframework.http.MediaType.*;
+import static org.springframework.http.MediaType.TEXT_PLAIN;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -15,7 +15,11 @@ import org.springframework.web.multipart.MultipartFile;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.document.DocumentUploadClientApi;
 import uk.gov.hmcts.reform.document.domain.UploadResponse;
-import uk.gov.hmcts.reform.sscs.ccd.domain.*;
+import uk.gov.hmcts.reform.sscs.ccd.domain.DocumentLink;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocument;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocumentDetails;
 import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.domain.pdf.ByteArrayMultipartFile;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
@@ -63,13 +67,8 @@ public class RoboticsJsonUploadService {
         if (null == updatedCaseData) {
             log.info("Case data for case {} was not updated with Robotics JSON document", caseDetails.getId());
         } else {
-            try {
-                ccdService.updateCase(updatedCaseData, caseDetails.getId(),
-                        "attachRoboticsJson", "", "", idamTokens);
-            } catch (Exception e) {
-                log.info("Failed to update ccd case with Robotics JSON but carrying on [" + caseDetails.getId() + "] ["
-                        + caseData.getCaseReference() + "]", e);
-            }
+            ccdService.updateCase(updatedCaseData, caseDetails.getId(),
+                    "attachRoboticsJson", "", "", idamTokens);
         }
 
     }
@@ -98,14 +97,8 @@ public class RoboticsJsonUploadService {
 
         String serviceAuthorization = authTokenGenerator.generate();
 
-        try {
-            return documentUploadClientApi
-                    .upload(S2S_TOKEN, serviceAuthorization, DM_STORE_USER_ID, files);
-        } catch (Exception e) {
-            log.info("Doc Store service failed to upload Robotics JSON, but carrying on", e);
-        }
-
-        return null;
+        return documentUploadClientApi
+                .upload(S2S_TOKEN, serviceAuthorization, DM_STORE_USER_ID, files);
     }
 
     private SscsDocument getRoboticsJsonDocument(DocumentLink documentLink) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadService.java
@@ -1,0 +1,143 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import static java.util.Collections.singletonList;
+import static org.springframework.http.MediaType.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.CollectionUtils;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.document.DocumentUploadClientApi;
+import uk.gov.hmcts.reform.document.domain.UploadResponse;
+import uk.gov.hmcts.reform.sscs.ccd.domain.*;
+import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
+import uk.gov.hmcts.reform.sscs.domain.pdf.ByteArrayMultipartFile;
+import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
+
+@Service
+@Slf4j
+public class RoboticsJsonUploadService {
+    private static final String DM_STORE_USER_ID = "sscs";
+    private static final String S2S_TOKEN = "oauth2Token";
+    private static final String ROBOTICS_JSON_FILENAME = "robotics_json.txt";
+
+    private final CcdService ccdService;
+    private final DocumentUploadClientApi documentUploadClientApi;
+    private final AuthTokenGenerator authTokenGenerator;
+
+    @Autowired
+    RoboticsJsonUploadService(
+            DocumentUploadClientApi documentUploadClientApi,
+            AuthTokenGenerator authTokenGenerator,
+            CcdService ccdService) {
+
+        this.documentUploadClientApi = documentUploadClientApi;
+        this.authTokenGenerator = authTokenGenerator;
+        this.ccdService = ccdService;
+    }
+
+    public void updateCaseWithRoboticsJson(
+            JSONObject roboticsJson,
+            SscsCaseData caseData,
+            SscsCaseDetails caseDetails,
+            IdamTokens idamTokens) {
+
+        ByteArrayMultipartFile file = ByteArrayMultipartFile.builder()
+                .content(roboticsJson.toString().getBytes())
+                .name(ROBOTICS_JSON_FILENAME)
+                .contentType(TEXT_PLAIN)
+                .build();
+
+        log.info("Uploading Robotics JSON for case {}", caseDetails.getId());
+        UploadResponse uploadResponse = uploadRoboticsJson(singletonList(file));
+
+        log.info("Attaching Robotics JSON to case {}", caseDetails.getId());
+        SscsCaseData updatedCaseData = attachRoboticsJsonToCaseData(caseData, uploadResponse);
+
+        if (null == updatedCaseData) {
+            log.info("Case data for case {} was not updated with Robotics JSON document", caseDetails.getId());
+        } else {
+            try {
+                ccdService.updateCase(updatedCaseData, caseDetails.getId(),
+                        "attachRoboticsJson", "", "", idamTokens);
+            } catch (Exception e) {
+                log.info("Failed to update ccd case with Robotics JSON but carrying on [" + caseDetails.getId() + "] ["
+                        + caseData.getCaseReference() + "]", e);
+            }
+        }
+
+    }
+
+    public SscsCaseData attachRoboticsJsonToCaseData(SscsCaseData caseData, UploadResponse uploadResponse) {
+        DocumentLink documentLink = getDocumentLink(uploadResponse);
+
+        if (null != documentLink) {
+            log.info("Robotics JSON Document for CCD Case {} uploaded to {}", caseData.getCcdCaseId(), documentLink);
+
+            SscsDocument roboticsJsonDocument = getRoboticsJsonDocument(documentLink);
+
+            log.info("Adding Robotics JSON document to CCD Case Id {}", caseData.getCcdCaseId());
+
+            List<SscsDocument> sscsDocumentList = updateCaseDataDocuments(caseData, roboticsJsonDocument);
+            caseData.setSscsDocument(sscsDocumentList);
+
+            return caseData;
+        }
+
+        return null;
+
+    }
+
+    private SscsDocument getRoboticsJsonDocument(DocumentLink documentLink) {
+        SscsDocumentDetails roboticsJsonDocumentDetails = SscsDocumentDetails.builder()
+                .documentFileName(ROBOTICS_JSON_FILENAME)
+                .documentDateAdded(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
+                .documentLink(documentLink)
+                .build();
+
+        return new SscsDocument(roboticsJsonDocumentDetails);
+    }
+
+    private DocumentLink getDocumentLink(UploadResponse uploadResponse) {
+        if (null != uploadResponse) {
+            final String href = uploadResponse.getEmbedded().getDocuments().get(0).links.binary.href;
+            return DocumentLink.builder().documentUrl(href).build();
+        } else {
+            log.info("No document link available - document store may be down");
+        }
+
+        return null;
+
+    }
+
+    private List<SscsDocument> updateCaseDataDocuments(SscsCaseData caseData, SscsDocument roboticsJsonDocument) {
+        List<SscsDocument> sscsDocumentList = caseData.getSscsDocument();
+        if (CollectionUtils.isEmpty(sscsDocumentList)) {
+            sscsDocumentList = singletonList(roboticsJsonDocument);
+        } else {
+            sscsDocumentList.add(roboticsJsonDocument);
+        }
+        return sscsDocumentList;
+    }
+
+    public UploadResponse uploadRoboticsJson(List<MultipartFile> files) {
+
+        String serviceAuthorization = authTokenGenerator.generate();
+
+        try {
+            return documentUploadClientApi
+                    .upload(S2S_TOKEN, serviceAuthorization, DM_STORE_USER_ID, files);
+        } catch (Exception e) {
+            log.info("Doc Store service failed to upload Robotics JSON, but carrying on", e);
+        }
+
+        return null;
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadServiceTest.java
@@ -1,0 +1,133 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.*;
+
+import java.util.Collections;
+import java.util.List;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.springframework.web.client.RestClientException;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.document.DocumentUploadClientApi;
+import uk.gov.hmcts.reform.document.domain.Document;
+import uk.gov.hmcts.reform.document.domain.UploadResponse;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
+import uk.gov.hmcts.reform.sscs.domain.email.EmailAttachment;
+import uk.gov.hmcts.reform.sscs.domain.email.RoboticsEmailTemplate;
+import uk.gov.hmcts.reform.sscs.domain.robotics.RoboticsWrapper;
+import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
+import uk.gov.hmcts.reform.sscs.json.RoboticsJsonMapper;
+import uk.gov.hmcts.reform.sscs.json.RoboticsJsonValidator;
+
+public class RoboticsJsonUploadServiceTest {
+
+    private static final String DUMMY_SERVICE_AUTHORIZATION_TOKEN = "serviceAuthorization";
+    private static final String DUMMY_OAUTH_2_TOKEN = "oauth2Token";
+
+    @Mock
+    private DocumentUploadClientApi documentUploadClientApi;
+
+    @Mock
+    private AuthTokenGenerator authTokenGenerator;
+
+    @Mock
+    private CcdService ccdService;
+
+    @Mock
+    private IdamTokens idamTokens;
+
+    @Mock
+    private JSONObject roboticsJson;
+
+    private RoboticsJsonUploadService service;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+
+        service = new RoboticsJsonUploadService(
+                documentUploadClientApi,
+                authTokenGenerator,
+                ccdService);
+
+        given(authTokenGenerator.generate()).willReturn(DUMMY_SERVICE_AUTHORIZATION_TOKEN);
+    }
+
+    @Test
+    public void willUpdateCaseWithRoboticsJson() {
+
+        UploadResponse uploadResponse = createUploadResponse();
+        given(documentUploadClientApi.upload(
+                eq(DUMMY_OAUTH_2_TOKEN),
+                eq(DUMMY_SERVICE_AUTHORIZATION_TOKEN),
+                anyString(),
+                any())).willReturn(uploadResponse);
+
+        SscsCaseData caseData = buildCaseData();
+        SscsCaseDetails caseDetails = convertCaseDetailsToSscsCaseDetails(buildCaseDetails());
+        service
+                .updateCaseWithRoboticsJson(
+                        roboticsJson,
+                        caseData,
+                        caseDetails,
+                        idamTokens);
+
+        verify(ccdService, times(1)).updateCase(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void willNotAttemptToUpdateCaseIfDocumentStoreIsDown() {
+
+        given(documentUploadClientApi.upload(eq(DUMMY_OAUTH_2_TOKEN), eq(DUMMY_SERVICE_AUTHORIZATION_TOKEN), anyString(), any()))
+                .willThrow(new RestClientException("Document store is down"));
+
+        SscsCaseData caseData = buildCaseData();
+        SscsCaseDetails caseDetails = convertCaseDetailsToSscsCaseDetails(buildCaseDetails());
+        service
+            .updateCaseWithRoboticsJson(
+                    roboticsJson,
+                    caseData,
+                    caseDetails,
+                    idamTokens);
+
+        verify(ccdService, never()).updateCase(any(), any(), any(), any(), any(), any());
+    }
+
+    private UploadResponse createUploadResponse() {
+        UploadResponse response = mock(UploadResponse.class);
+        UploadResponse.Embedded embedded = mock(UploadResponse.Embedded.class);
+        when(response.getEmbedded()).thenReturn(embedded);
+        Document document = createDocument();
+        when(embedded.getDocuments()).thenReturn(Collections.singletonList(document));
+        return response;
+    }
+
+    private Document createDocument() {
+        Document.Links links = new Document.Links();
+        Document.Link link = new Document.Link();
+        links.binary = new Document.Link();
+        link.href = "some location";
+        links.self = link;
+        links.binary.href = "some location";
+
+        Document document = new Document();
+        document.links = links;
+        return document;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadServiceTest.java
@@ -78,24 +78,6 @@ public class RoboticsJsonUploadServiceTest {
         verify(ccdService, times(1)).updateCase(any(), any(), any(), any(), any(), any());
     }
 
-    @Test
-    public void willNotAttemptToUpdateCaseIfDocumentStoreIsDown() {
-
-        given(documentUploadClientApi.upload(eq(DUMMY_OAUTH_2_TOKEN), eq(DUMMY_SERVICE_AUTHORIZATION_TOKEN), anyString(), any()))
-                .willThrow(new RestClientException("Document store is down"));
-
-        SscsCaseData caseData = buildCaseData();
-        SscsCaseDetails caseDetails = convertCaseDetailsToSscsCaseDetails(buildCaseDetails());
-        service
-            .updateCaseWithRoboticsJson(
-                    roboticsJson,
-                    caseData,
-                    caseDetails,
-                    idamTokens);
-
-        verify(ccdService, never()).updateCase(any(), any(), any(), any(), any(), any());
-    }
-
     private UploadResponse createUploadResponse() {
         UploadResponse response = mock(UploadResponse.class);
         UploadResponse.Embedded embedded = mock(UploadResponse.Embedded.class);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadServiceTest.java
@@ -1,39 +1,26 @@
 package uk.gov.hmcts.reform.sscs.service;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.*;
 
 import java.util.Collections;
-import java.util.List;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.springframework.web.client.RestClientException;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
-import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.document.DocumentUploadClientApi;
 import uk.gov.hmcts.reform.document.domain.Document;
 import uk.gov.hmcts.reform.document.domain.UploadResponse;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
-import uk.gov.hmcts.reform.sscs.domain.email.EmailAttachment;
-import uk.gov.hmcts.reform.sscs.domain.email.RoboticsEmailTemplate;
-import uk.gov.hmcts.reform.sscs.domain.robotics.RoboticsWrapper;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
-import uk.gov.hmcts.reform.sscs.json.RoboticsJsonMapper;
-import uk.gov.hmcts.reform.sscs.json.RoboticsJsonValidator;
 
 public class RoboticsJsonUploadServiceTest {
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsJsonUploadServiceTest.java
@@ -12,7 +12,6 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.springframework.web.client.RestClientException;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.document.DocumentUploadClientApi;
 import uk.gov.hmcts.reform.document.domain.Document;

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsServiceTest.java
@@ -43,6 +43,9 @@ public class RoboticsServiceTest {
     @Mock
     private RoboticsEmailTemplate roboticsEmailTemplate;
 
+    @Mock
+    private RoboticsJsonUploadService roboticsJsonUploadService;
+
     private RoboticsService service;
 
     @Captor
@@ -52,7 +55,13 @@ public class RoboticsServiceTest {
     public void setup() {
         initMocks(this);
 
-        service = new RoboticsService(airlookupService, emailService, roboticsJsonMapper, roboticsJsonValidator, roboticsEmailTemplate);
+        service = new RoboticsService(
+                airlookupService,
+                emailService,
+                roboticsJsonMapper,
+                roboticsJsonValidator,
+                roboticsEmailTemplate,
+                roboticsJsonUploadService);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsServiceTest.java
@@ -172,7 +172,7 @@ public class RoboticsServiceTest {
     }
 
     @Test
-    public void generatingRoboticsStoresTheJson() {
+    public void generatingRoboticsReturnsTheJson() {
 
         SscsCaseData appeal = buildCaseData();
 
@@ -184,8 +184,8 @@ public class RoboticsServiceTest {
 
         given(emailService.generateUniqueEmailId(appeal.getAppeal().getAppellant())).willReturn("Bloggs_123");
 
-        service.sendCaseToRobotics(appeal, 123L, "AB12 XYZ", null);
+        JSONObject roboticsJson = service.sendCaseToRobotics(appeal, 123L, "AB12 XYZ", null);
 
-        assertThat(service.getRoboticsJson(), is(mappedJson));
+        assertThat(roboticsJson, is(mappedJson));
     }
 }


### PR DESCRIPTION
Moved the RoboticsJsonUploadService out of the Tribunals API into this common library, where a call to the RoboticsService will delegate the JSON upload tasks to the RoboticsJsonUploadService.

This was moved out of Tribunals API, as Sonar Scan was failing the code due to too many services being passed to the SubmitAppealService.