### PR TITLE
SSCS-6110 Add logging robotics email send

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/RoboticsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/RoboticsService.java
@@ -97,9 +97,13 @@ public class RoboticsService {
     }
 
     private void sendJsonByEmail(Appellant appellant, JSONObject json, byte[] pdf, Map<String, byte[]> additionalEvidence, boolean isScottish) {
+        log.info("Generating unique email id");
         String appellantUniqueId = emailService.generateUniqueEmailId(appellant);
+        log.info("Add default attachments");
         List<EmailAttachment> attachments = addDefaultAttachment(json, pdf, appellantUniqueId);
+        log.info("Add additional evidence");
         addAdditionalEvidenceAttachments(additionalEvidence, attachments);
+        log.info("Send email");
         emailService.sendEmail(
                 roboticsEmailTemplate.generateEmail(
                         appellantUniqueId,


### PR DESCRIPTION
Add extra logging around sending the robotics emails. This will
hopefully help us find why some appeals are failing to send to robotics.

### JIRA link (if applicable) ###

https://github.com/hmcts/sscs-pdf-email-common/pull/111

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
